### PR TITLE
Enable boot without watchdog

### DIFF
--- a/main.c
+++ b/main.c
@@ -157,9 +157,14 @@ EFI_STATUS efi_main(EFI_HANDLE image_handle, EFI_SYSTEM_TABLE *system_table)
 		    EFI_OUT_OF_RESOURCES);
 	}
 
-	status = scan_devices(loaded_image, bg_loader_params.timeout);
-	if (EFI_ERROR(status)) {
-		error_exit(L"Could not probe watchdog.", status);
+	if (bg_loader_params.timeout == 0) {
+		Print(L"Watchdog is disabled.\n");
+		return EFI_SUCCESS;
+	} else {
+		status = scan_devices(loaded_image, bg_loader_params.timeout);
+		if (EFI_ERROR(status)) {
+			error_exit(L"Could not probe watchdog.", status);
+		}
 	}
 
 	/* Load and start image */

--- a/tools/bg_setenv.c
+++ b/tools/bg_setenv.c
@@ -338,7 +338,7 @@ static error_t parse_opt(int key, char *arg, struct argp_state *state)
 		break;
 	case 'w':
 		i = parse_int(arg);
-		if (errno || i == 0) {
+		if (errno || i < 0) {
 			fprintf(stderr,
 				"Invalid watchdog timeout specified.\n");
 			return 1;


### PR DESCRIPTION
This patch allows booting an image without arming watchdog timer
whwn "watchdog=0" parameter is passed to the to the module.

This covers the use case when availability of a hardware driver is
unknown ahead of time and can only be established upon first boot.
The code that runs on the first boot can then identify if supported
hardware watchdog is available and the required driver is present
in the kernel and either update boot configuration re-arming the
timer or issuing a warning unsupported hardware. This also allows
for booting images in virtual environments.

Allow "watchdog" be equal "0"

Move bypass switch to efi_main